### PR TITLE
Add loongarch64 architecture support

### DIFF
--- a/src/build-data/arch/loongarch64.txt
+++ b/src/build-data/arch/loongarch64.txt
@@ -1,0 +1,3 @@
+family loongarch
+endian little
+wordsize 64

--- a/src/build-data/detect_arch.cpp
+++ b/src/build-data/detect_arch.cpp
@@ -70,6 +70,9 @@
      RISCV32
   #endif
 
+#elif defined(__loongarch64)
+  LOONGARCH64
+
 #else
   UNKNOWN
 


### PR DESCRIPTION
Add loongarch64 architecture support， please review, thanks.   
  @yetist @xen0n @zhuyaliang @cnmushiba @zwaizwai @loongarch64/dev-team 

测试项通过：
LD_LIBRARY_PATH=.  ./botan-test
```
XMSS/SHAKE_10_256 signature verification ran 21 tests in 68.86 msec all ok
XMSS/SHAKE_10_512 signature verification ran 21 tests in 219.77 msec all ok
XMSS/SHAKE_16_256 signature verification ran 21 tests in 66.52 msec all ok
XMSS/SHAKE_16_512 signature verification ran 21 tests in 130.27 msec all ok
XMSS/SHAKE_20_256 signature verification ran 21 tests in 32.51 msec all ok
XMSS/SHAKE_20_512 signature verification ran 21 tests in 116.53 msec all ok
xmss_verify_invalid:
XMSS/SHA2_10_256 verify invalid signature ran 28 tests in 27.57 msec all ok
XMSS/SHA2_10_512 verify invalid signature ran 28 tests in 68.51 msec all ok
XMSS/SHA2_16_256 verify invalid signature ran 28 tests in 33.07 msec all ok
XMSS/SHA2_16_512 verify invalid signature ran 28 tests in 84.17 msec all ok
XMSS/SHA2_20_256 verify invalid signature ran 28 tests in 33.85 msec all ok
XMSS/SHA2_20_512 verify invalid signature ran 28 tests in 84.03 msec all ok
XMSS/SHAKE_10_256 verify invalid signature ran 28 tests in 23.71 msec all ok
XMSS/SHAKE_10_512 verify invalid signature ran 28 tests in 78.81 msec all ok
XMSS/SHAKE_16_256 verify invalid signature ran 28 tests in 29.26 msec all ok
XMSS/SHAKE_16_512 verify invalid signature ran 28 tests in 96.19 msec all ok
XMSS/SHAKE_20_256 verify invalid signature ran 28 tests in 29.50 msec all ok
XMSS/SHAKE_20_512 verify invalid signature ran 28 tests in 98.81 msec all ok
Tests complete ran 2543560 tests in 25.44 sec all tests ok
zhangna@loongson-pc:~/lucky-github/botan$ arch 
loongarch64

```